### PR TITLE
Feat/1v1 inquire develop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,18 +44,28 @@ dependencies {
 
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    //Webflux
+    // Webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    // mongodb
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+
+
     //Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
     //JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+
+
     // test
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/controller/InquireController.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/controller/InquireController.java
@@ -4,12 +4,15 @@ import com.bitcamp.drrate.domain.inquire.entity.ChatMessage;
 import com.bitcamp.drrate.domain.inquire.entity.ChatRoom;
 import com.bitcamp.drrate.domain.inquire.service.ChatRoomService;
 import com.bitcamp.drrate.domain.inquire.service.KafkaProducer;
+import com.bitcamp.drrate.domain.jwt.JWTUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
+
+import java.util.Objects;
 
 @Controller
 @RequiredArgsConstructor
@@ -17,19 +20,25 @@ public class InquireController {
     private final KafkaProducer kafkaProducer;
     private final ChatRoomService chatRoomService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final JWTUtil jwtUtil;
 
-    @MessageMapping("/chat/room/{roomId}") // 클라이언트에서 발행하는 경로
-    @SendTo("/sub/chat/room/{roomId}")     // 클라이언트로 브로드캐스팅하는 경로
-    public void handleChatMessage(@DestinationVariable String roomId, ChatMessage chatMessage) {
-        System.out.println("Received message: " + chatMessage);
+    @MessageMapping("/chat/room") // 클라이언트에서 발행하는 경로
+    @SendTo("/sub/chat/room")     // 클라이언트로 브로드캐스팅하는 경로
+    public void handleChatMessage(ChatMessage chatMessage, StompHeaderAccessor accessor) {
+        System.out.println("accessor : "+accessor);
+        String role = String.valueOf(accessor.getSessionAttributes().get("role"));
+        String senderId = String.valueOf(accessor.getSessionAttributes().get("userId"));
 
+
+        ChatRoom chatRoom = null;
         // 1:1 문의용 ChatRoom 생성 또는 조회
-        ChatRoom chatRoom = chatRoomService.getOrCreateChatRoom(roomId);
-
+        if(Objects.equals(role, "ROLE_USER")){
+            chatRoom = chatRoomService.getOrCreateChatRoom(senderId);
+        }
         // Kafka에 메시지 발행
-        kafkaProducer.sendMessage(chatRoom.getTopicName(), chatMessage.getContent(), roomId);
+        kafkaProducer.sendMessage(chatRoom, chatMessage.getContent(), senderId);
 
         // WebSocket으로 클라이언트에 메시지 전달
-        messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, chatMessage);
+        messagingTemplate.convertAndSend("/sub/chat/room/" + chatRoom.getId(), chatMessage);
     }
 }

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/controller/InquireController.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/controller/InquireController.java
@@ -1,0 +1,35 @@
+package com.bitcamp.drrate.domain.inquire.controller;
+
+import com.bitcamp.drrate.domain.inquire.entity.ChatMessage;
+import com.bitcamp.drrate.domain.inquire.entity.ChatRoom;
+import com.bitcamp.drrate.domain.inquire.service.ChatRoomService;
+import com.bitcamp.drrate.domain.inquire.service.KafkaProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class InquireController {
+    private final KafkaProducer kafkaProducer;
+    private final ChatRoomService chatRoomService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat/room/{roomId}") // 클라이언트에서 발행하는 경로
+    @SendTo("/sub/chat/room/{roomId}")     // 클라이언트로 브로드캐스팅하는 경로
+    public void handleChatMessage(@DestinationVariable String roomId, ChatMessage chatMessage) {
+        System.out.println("Received message: " + chatMessage);
+
+        // 1:1 문의용 ChatRoom 생성 또는 조회
+        ChatRoom chatRoom = chatRoomService.getOrCreateChatRoom(roomId);
+
+        // Kafka에 메시지 발행
+        kafkaProducer.sendMessage(chatRoom.getTopicName(), chatMessage.getContent(), roomId);
+
+        // WebSocket으로 클라이언트에 메시지 전달
+        messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, chatMessage);
+    }
+}

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/entity/ChatMessage.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/entity/ChatMessage.java
@@ -11,6 +11,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "chatMessages")  // MongoDB의 컬렉션 이름
 public class ChatMessage extends BaseEntity {
     private String roomId;
-    private String sender;
+    private String senderId;
     private String content;
 }

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/entity/ChatMessage.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/entity/ChatMessage.java
@@ -1,0 +1,16 @@
+package com.bitcamp.drrate.domain.inquire.entity;
+
+
+import com.bitcamp.drrate.global.entity.BaseEntity;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Setter
+@Document(collection = "chatMessages")  // MongoDB의 컬렉션 이름
+public class ChatMessage extends BaseEntity {
+    private String roomId;
+    private String sender;
+    private String content;
+}

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/entity/ChatRoom.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/entity/ChatRoom.java
@@ -12,6 +12,5 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class ChatRoom extends BaseEntity {
     @Id
     private String id;
-    private String sender;
     private String topicName;
 }

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/entity/ChatRoom.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/entity/ChatRoom.java
@@ -1,0 +1,17 @@
+package com.bitcamp.drrate.domain.inquire.entity;
+
+
+import com.bitcamp.drrate.global.entity.BaseEntity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter @Setter
+@Document(collection = "chatRooms")
+public class ChatRoom extends BaseEntity {
+    @Id
+    private String id;
+    private String sender;
+    private String topicName;
+}

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/repository/ChatMessageRepository.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/repository/ChatMessageRepository.java
@@ -1,0 +1,9 @@
+package com.bitcamp.drrate.domain.inquire.repository;
+
+import com.bitcamp.drrate.domain.inquire.entity.ChatMessage;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository("MongoChatMessageRepository")
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+}

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/repository/ChatRoomRepository.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.bitcamp.drrate.domain.inquire.repository;
+
+import com.bitcamp.drrate.domain.inquire.entity.ChatRoom;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository("MongoChatRoomRepository")
+public interface ChatRoomRepository extends MongoRepository<ChatRoom, String> {
+}

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/service/ChatRoomService.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/service/ChatRoomService.java
@@ -1,0 +1,41 @@
+package com.bitcamp.drrate.domain.inquire.service;
+
+import com.bitcamp.drrate.domain.inquire.entity.ChatRoom;
+import com.bitcamp.drrate.domain.inquire.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final KafkaTopicService kafkaTopicService;
+
+    public ChatRoom getOrCreateChatRoom(String roomId) {
+        // 기존 채팅방 조회
+        Optional<ChatRoom> existingRoom = chatRoomRepository.findById(roomId);
+        if (existingRoom.isPresent()) {
+            System.out.println("Existing ChatRoom found: " + existingRoom.get().getTopicName());
+            return existingRoom.orElse(null);
+        }
+
+        // 새로운 채팅방 생성
+        String topicName = "chat-room-" + roomId;
+        ChatRoom newRoom = new ChatRoom();
+        newRoom.setId(roomId);
+        newRoom.setTopicName(topicName);
+        newRoom.setCreatedAt(LocalDateTime.now());
+
+        // MongoDB 저장
+        chatRoomRepository.save(newRoom);
+
+        // Kafka 토픽 생성
+        kafkaTopicService.createTopic(topicName);
+
+        System.out.println("New ChatRoom created: " + topicName);
+        return newRoom;
+    }
+}

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaConsumer.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaConsumer.java
@@ -29,12 +29,13 @@ public class KafkaConsumer {
             // roomId와 메시지 추출
             String roomId = messagePayload.get("roomId");
             String messageContent = messagePayload.get("message");
+            String senderId  = messagePayload.get("senderId");
 
             // ChatMessage 객체 생성
             ChatMessage chatMessage = new ChatMessage();
             chatMessage.setRoomId(roomId);
             chatMessage.setContent(messageContent);
-            chatMessage.setCreatedAt(LocalDateTime.now());
+            chatMessage.setSenderId(senderId);
 
             // MongoDB에 저장
             chatMessageRepository.save(chatMessage);

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaConsumer.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaConsumer.java
@@ -1,0 +1,50 @@
+package com.bitcamp.drrate.domain.inquire.service;
+
+import com.bitcamp.drrate.domain.inquire.entity.ChatMessage;
+import com.bitcamp.drrate.domain.inquire.repository.ChatMessageRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaConsumer {
+    private final ChatMessageRepository chatMessageRepository;
+    private final ObjectMapper objectMapper;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @KafkaListener(topicPattern =  "chat-room-.*", groupId = "chat_group")
+    public void consume(String jsonMessage) {
+        try {
+            System.out.println(jsonMessage);
+            // JSON 문자열을 Map으로 변환
+            Map<String, String> messagePayload = objectMapper.readValue(jsonMessage, new TypeReference<Map<String, String>>() {});
+            System.out.println("hello");
+            // roomId와 메시지 추출
+            String roomId = messagePayload.get("roomId");
+            String messageContent = messagePayload.get("message");
+
+            // ChatMessage 객체 생성
+            ChatMessage chatMessage = new ChatMessage();
+            chatMessage.setRoomId(roomId);
+            chatMessage.setContent(messageContent);
+            chatMessage.setCreatedAt(LocalDateTime.now());
+
+            // MongoDB에 저장
+            chatMessageRepository.save(chatMessage);
+
+            // WebSocket으로 클라이언트에 메시지 브로드캐스팅
+            messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, chatMessage);
+
+            System.out.println("Broadcasted message to roomId " + roomId + ": " + chatMessage);
+        } catch (Exception e) {
+            System.err.println("Error consuming message from Kafka: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaProducer.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaProducer.java
@@ -1,0 +1,36 @@
+package com.bitcamp.drrate.domain.inquire.service;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper; // ObjectMapper를 DI로 주입받아 재사용
+
+    public void sendMessage(String topic, String message, String roomId) {
+        try {
+            // roomId와 message를 포함한 JSON 객체 생성
+            Map<String, String> messagePayload = Map.of(
+                    "roomId", roomId,
+                    "message", message
+            );
+
+            // JSON 직렬화
+            String jsonMessage = objectMapper.writeValueAsString(messagePayload);
+
+            // Kafka에 메시지 발행
+            kafkaTemplate.send(topic, jsonMessage);
+            System.out.println("Produced message to Kafka: " + jsonMessage);
+        } catch (Exception e) {
+            System.err.println("Error sending message to Kafka: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaProducer.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaProducer.java
@@ -1,6 +1,8 @@
 package com.bitcamp.drrate.domain.inquire.service;
 
 
+import com.bitcamp.drrate.domain.inquire.entity.ChatMessage;
+import com.bitcamp.drrate.domain.inquire.entity.ChatRoom;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -14,19 +16,20 @@ public class KafkaProducer {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper; // ObjectMapper를 DI로 주입받아 재사용
 
-    public void sendMessage(String topic, String message, String roomId) {
+    public void sendMessage(ChatRoom chatRoom, String message, String senderId) {
         try {
             // roomId와 message를 포함한 JSON 객체 생성
             Map<String, String> messagePayload = Map.of(
-                    "roomId", roomId,
-                    "message", message
+                    "roomId", chatRoom.getId(),
+                    "message", message,
+                    "senderId" , senderId
             );
 
             // JSON 직렬화
             String jsonMessage = objectMapper.writeValueAsString(messagePayload);
 
             // Kafka에 메시지 발행
-            kafkaTemplate.send(topic, jsonMessage);
+            kafkaTemplate.send(chatRoom.getTopicName(), jsonMessage);
             System.out.println("Produced message to Kafka: " + jsonMessage);
         } catch (Exception e) {
             System.err.println("Error sending message to Kafka: " + e.getMessage());

--- a/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaTopicService.java
+++ b/src/main/java/com/bitcamp/drrate/domain/inquire/service/KafkaTopicService.java
@@ -1,0 +1,19 @@
+package com.bitcamp.drrate.domain.inquire.service;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaTopicService {
+    private final KafkaAdmin kafkaAdmin;
+
+
+    public void createTopic(String topicName) {
+        NewTopic topic = new NewTopic(topicName, 1, (short) 1);
+        kafkaAdmin.createOrModifyTopics(topic);
+        System.out.println("Kafka Topic Created: " + topicName);
+    }
+}

--- a/src/main/java/com/bitcamp/drrate/domain/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/bitcamp/drrate/domain/jwt/CustomLogoutFilter.java
@@ -10,7 +10,6 @@ import com.bitcamp.drrate.global.code.resultCode.ErrorStatus;
 import com.bitcamp.drrate.global.code.resultCode.SuccessStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -55,10 +54,10 @@ public class CustomLogoutFilter extends GenericFilterBean {
             return;
         }
 
-        String userId = jwtUtil.getUserId(accessToken);
+        Long userId = jwtUtil.getId(accessToken);
 
         /* userId 키값으로 refresh token이 있는지 */
-        String refreshToken = refreshTokenService.getRefreshToken(userId);
+        String refreshToken = refreshTokenService.getRefreshToken(String.valueOf(userId));
         if (refreshToken == null) {
             /* (중요) access token이 재발급되고 refresh기간이 만료될 수도 있음 => 이 경우는 access token 유효기간에 따라 로그아웃 권한 부여 */
             if(jwtUtil.isExpired(accessToken)){
@@ -71,7 +70,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
                 }
             }
         }
-        refreshTokenService.deleteTokens(userId);
+        refreshTokenService.deleteTokens(String.valueOf(userId));
         setAuthorizedResponse(response);
     }
     private void setAuthorizedResponse(HttpServletResponse response) throws IOException {

--- a/src/main/java/com/bitcamp/drrate/domain/jwt/JWTFilter.java
+++ b/src/main/java/com/bitcamp/drrate/domain/jwt/JWTFilter.java
@@ -2,6 +2,7 @@ package com.bitcamp.drrate.domain.jwt;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Optional;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -58,9 +59,12 @@ public class JWTFilter extends OncePerRequestFilter {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         } // if
-        String userId = jwtUtil.getUserId(accessToken);
+        Long userId = jwtUtil.getId(accessToken);
 
-        Users users = usersRepository.findByUserId(userId);
+        System.out.println("userId: " + userId);
+
+        Users users = usersRepository.findUsersById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found for ID: " + userId));
         
         CustomUserDetails customUserDetails = new CustomUserDetails(users);
 

--- a/src/main/java/com/bitcamp/drrate/domain/jwt/JWTUtil.java
+++ b/src/main/java/com/bitcamp/drrate/domain/jwt/JWTUtil.java
@@ -21,9 +21,6 @@ public class JWTUtil {
         this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public String getUserId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", String.class);
-    }
     
     public String getRole(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);

--- a/src/main/java/com/bitcamp/drrate/domain/users/entity/Users.java
+++ b/src/main/java/com/bitcamp/drrate/domain/users/entity/Users.java
@@ -1,7 +1,8 @@
 package com.bitcamp.drrate.domain.users.entity;
 
 
-import com.bitcamp.drrate.global.config.entity.BaseEntity;
+
+import com.bitcamp.drrate.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/bitcamp/drrate/global/code/resultCode/ErrorStatus.java
+++ b/src/main/java/com/bitcamp/drrate/global/code/resultCode/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus implements ErrorCode {
     SESSION_HEADER_NOT_FOUND(HttpStatus.OK, "SESSION400", "헤더에 세션 정보가 존재하지 않습니다."),
     SESSION_ACCESS_NOT_VALID(HttpStatus.OK, "SESSION401", "액세스 토큰 값이 유효하지 않습니다."),
     SESSION_REFRESH_NOT_VALID(HttpStatus.OK, "SESSION401", "리프레쉬 토큰 값이 유효하지 않습니다."),
+    SESSION_ACCESS_EXPIRED(HttpStatus.OK, "SESSION401", "액세스 토큰이 만료되었습니다"),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL501","서버 오류")
     ;

--- a/src/main/java/com/bitcamp/drrate/global/config/JpaConfig.java
+++ b/src/main/java/com/bitcamp/drrate/global/config/JpaConfig.java
@@ -1,0 +1,17 @@
+package com.bitcamp.drrate.global.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(
+        basePackages = "com.bitcamp.drrate.domain",
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.REGEX,
+                pattern = "com\\.bitcamp\\.drrate\\.domain\\.inquire\\..*"
+        )
+)
+public class JpaConfig {
+}

--- a/src/main/java/com/bitcamp/drrate/global/config/KafkaConfig.java
+++ b/src/main/java/com/bitcamp/drrate/global/config/KafkaConfig.java
@@ -1,0 +1,19 @@
+package com.bitcamp.drrate.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.Map;
+
+
+// Kafka 토픽 생성에 필요한 설정을 추가
+@Configuration
+public class KafkaConfig {
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        return new KafkaAdmin(Map.of(
+                "bootstrap.servers", "localhost:9092"
+        ));
+    }
+}

--- a/src/main/java/com/bitcamp/drrate/global/config/MongoConfig.java
+++ b/src/main/java/com/bitcamp/drrate/global/config/MongoConfig.java
@@ -1,0 +1,9 @@
+package com.bitcamp.drrate.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoRepositories(basePackages = "com.bitcamp.drrate.domain.inquire")
+public class MongoConfig {
+}

--- a/src/main/java/com/bitcamp/drrate/global/config/SecurityConfig.java
+++ b/src/main/java/com/bitcamp/drrate/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -38,6 +39,7 @@ public class SecurityConfig {
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
     }
+
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
@@ -53,7 +55,8 @@ public class SecurityConfig {
         //csrf disable
         http.csrf(auth -> auth.disable());
 
-        http.cors(withDefaults -> {});
+        http.cors(withDefaults -> {
+        });
         //폼 로그인 방식 disalbe
         // http.formLogin(auth -> auth
         //         .loginPage("/loginForm")
@@ -69,6 +72,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/login", "/", "/join", "/reissue", "/login/**", "/loginForm").permitAll()
+                .requestMatchers("/ws/**").authenticated()
                 .requestMatchers("/admin").hasRole("ADMIN")
                 .anyRequest().authenticated());
 
@@ -76,21 +80,22 @@ public class SecurityConfig {
         //필터 추가 LoginFilter()는 인자를 받음 (AuthenticationManager() 메소드에 authenticationConfiguration 객체를 넣어야 함) 따라서 등록 필요
         http.addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
         //세션 설정
-        http.addFilterBefore(new CustomLogoutFilter(jwtUtil,objectMapper,refreshTokenService), LogoutFilter.class);
+        http.addFilterBefore(new CustomLogoutFilter(jwtUtil, objectMapper, refreshTokenService), LogoutFilter.class);
 
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }
+
     @Bean
-        public CorsFilter corsFilter() {
-            UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-            CorsConfiguration config = new CorsConfiguration();
-            config.setAllowCredentials(true); // 쿠키 포함 허용
-            config.addAllowedOriginPattern("http://localhost:5173"); // 허용할 Origin
-            config.addAllowedHeader("*"); // 모든 헤더 허용
-            config.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
-            source.registerCorsConfiguration("/**", config);
-            return new CorsFilter(source);
-        }
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true); // 쿠키 포함 허용
+        config.addAllowedOriginPattern("http://localhost:5173"); // 허용할 Origin
+        config.addAllowedHeader("*"); // 모든 헤더 허용
+        config.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
 }

--- a/src/main/java/com/bitcamp/drrate/global/config/SecurityConfig.java
+++ b/src/main/java/com/bitcamp/drrate/global/config/SecurityConfig.java
@@ -93,8 +93,7 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true); // 쿠키 포함 허용
-        config.addAllowedOrigin("http://localhost:8080");
-        config.addAllowedOrigin("https://jiangxy.github.io");
+        config.addAllowedOrigin("https://jiangxy.github.io"); // websocket test용 origin
         config.addAllowedOriginPattern("http://localhost:5173"); // 허용할 Origin
         config.addAllowedHeader("*"); // 모든 헤더 허용
         config.addAllowedMethod("*"); // 모든 HTTP 메서드 허용

--- a/src/main/java/com/bitcamp/drrate/global/config/SecurityConfig.java
+++ b/src/main/java/com/bitcamp/drrate/global/config/SecurityConfig.java
@@ -73,8 +73,7 @@ public class SecurityConfig {
         http.httpBasic(auth -> auth.disable());
 
         http.authorizeHttpRequests(auth -> auth
-                .requestMatchers("/login", "/", "/join", "/reissue", "/login/**", "/loginForm").permitAll()
-                .requestMatchers("/ws/**").authenticated()
+                .requestMatchers("/login", "/", "/join", "/reissue", "/login/**", "/loginForm", "/ws/**").permitAll()
                 .requestMatchers("/admin").hasRole("ADMIN")
                 .anyRequest().authenticated());
 
@@ -94,6 +93,8 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true); // 쿠키 포함 허용
+        config.addAllowedOrigin("http://localhost:8080");
+        config.addAllowedOrigin("https://jiangxy.github.io");
         config.addAllowedOriginPattern("http://localhost:5173"); // 허용할 Origin
         config.addAllowedHeader("*"); // 모든 헤더 허용
         config.addAllowedMethod("*"); // 모든 HTTP 메서드 허용

--- a/src/main/java/com/bitcamp/drrate/global/config/WebSocketConfig.java
+++ b/src/main/java/com/bitcamp/drrate/global/config/WebSocketConfig.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSocket
-@EnableWebSocketMessageBroker // 브로커 활성화 => subscriber에서 원하는 시점에 메세지 처리가 가능하고, scaleout에 용이하다.
+@EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final StompHandler stompHandler;
@@ -26,13 +26,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(final MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub"); // 내장된 메시지 브로커를 활성화하여 /sub로 시작하는 주소로 발행되는 메시지를 구독하는 클라이언트에게 전달
-           /*   .setRelayHost("127.0.0.1")
-                .setRelayPort(61613)
-                .setClientLogin("guest")
-                .setClientPasscode("guest")*/
-        //
-        registry.setApplicationDestinationPrefixes("/pub"); // 클라이언트가 메시지를 발행할 때 사용하는 주소의 접두어를 설정. 클라이언트가 메시지를 서버로 전송할 때 **/pub/**로 시작하는 경로를 사용해야 한다.
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
     }
 
     @Override

--- a/src/main/java/com/bitcamp/drrate/global/config/WebSocketConfig.java
+++ b/src/main/java/com/bitcamp/drrate/global/config/WebSocketConfig.java
@@ -4,17 +4,12 @@ import com.bitcamp.drrate.global.handler.stomp.StompExceptionHandler;
 import com.bitcamp.drrate.global.handler.stomp.StompHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
-import org.springframework.messaging.converter.MessageConverter;
-import org.springframework.messaging.converter.StringMessageConverter;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSocket
@@ -31,16 +26,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     }
 
     @Override
-    public void registerStompEndpoints(final StompEndpointRegistry registry) {
-        registry
-                .addEndpoint("/ws")  // 엔드 포인트 : /websocket
-                .setAllowedOrigins("*") // * 나중에 허용 도메인 추가 *
-                .withSockJS();
-        registry.setErrorHandler(stompExceptionHandler);
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        System.out.println("interceptors");
+        registration.interceptors(stompHandler);
     }
 
     @Override
-    public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(stompHandler);
+    public void registerStompEndpoints(final StompEndpointRegistry registry) {
+        registry
+                .addEndpoint("/ws")  // 엔드 포인트 : /websocket
+                .setAllowedOrigins("*"); // * 나중에 허용 도메인 추가 *
+       /* registry.setErrorHandler(stompExceptionHandler);*/
     }
 }

--- a/src/main/java/com/bitcamp/drrate/global/entity/BaseEntity.java
+++ b/src/main/java/com/bitcamp/drrate/global/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.bitcamp.drrate.global.config.entity;
+package com.bitcamp.drrate.global.entity;
 
 
 import jakarta.persistence.Column;

--- a/src/main/java/com/bitcamp/drrate/global/handler/stomp/StompExceptionHandler.java
+++ b/src/main/java/com/bitcamp/drrate/global/handler/stomp/StompExceptionHandler.java
@@ -3,12 +3,15 @@ package com.bitcamp.drrate.global.handler.stomp;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
 
+import javax.naming.AuthenticationException;
 import java.nio.charset.StandardCharsets;
 
 @Slf4j
@@ -18,12 +21,31 @@ public class StompExceptionHandler extends StompSubProtocolErrorHandler {
 
     @Override
     public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
-        log.error("WebSocket error occurred: {}", ex.getMessage(), ex);
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(clientMessage);
 
-        String errorMessage = ex.getMessage();
+        String sessionId = accessor.getSessionId();
+        StompCommand command = accessor.getCommand();
+        String errorMessage;
 
-        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        // 예외별 처리
+        if (ex instanceof AuthenticationException) {
+            errorMessage = "인증에 실패했습니다. 자격 증명을 확인해주세요.";
+        } else if (ex instanceof AccessDeniedException) {
+            errorMessage = "접근 권한이 없습니다.";
+        } else if (ex instanceof MessageConversionException) {
+            errorMessage = "잘못된 메시지 형식입니다.";
+        } else {
+            errorMessage = "예기치 못한 오류가 발생했습니다.";
+        }
+
+        errorMessage = String.format("[%s] 명령 처리 중 오류 발생 (세션: %s): %s",
+                command != null ? command.name() : "알 수 없음",
+                sessionId != null ? sessionId : "알 수 없음",
+                errorMessage);
+
         accessor.setMessage(errorMessage);
+        accessor.addNativeHeader("error-code", "WS-001");
+        accessor.addNativeHeader("error-description", errorMessage);
         accessor.setLeaveMutable(true);
 
         return MessageBuilder.createMessage(errorMessage.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());

--- a/src/main/java/com/bitcamp/drrate/global/handler/stomp/StompHandler.java
+++ b/src/main/java/com/bitcamp/drrate/global/handler/stomp/StompHandler.java
@@ -40,22 +40,26 @@ public class StompHandler implements ChannelInterceptor {
         // STOMP 메시지 헤더에서 Authorization 토큰 추출
         String token = accessor.getFirstNativeHeader("Authorization");
         if (token == null || !token.startsWith("Bearer ")) {
+            log.error("Authorization 헤더가 누락되었거나 잘못됨");
             throw new IllegalArgumentException(ErrorStatus.SESSION_HEADER_NOT_FOUND.getMessage());
         }
 
         token = token.substring(7);
         try {
             if (jwtUtil.isExpired(token)) {
+                log.error("JWT 토큰이 만료됨");
                 throw new IllegalArgumentException(ErrorStatus.SESSION_ACCESS_EXPIRED.getMessage());
             }
 
-            String userId = jwtUtil.getUserId(token);
+            Long userId = jwtUtil.getId(token);
 
-            if (usersRepository.findUsersById(Long.parseLong(userId)).isEmpty()) {
+            if (usersRepository.findUsersById(userId)==null){
+                log.error("사용자를 찾을 수 없음");
                 throw new IllegalArgumentException(ErrorStatus.USER_ID_CANNOT_FOUND.getMessage());
             }
 
         } catch (Exception e) {
+            log.error("JWT 검증 실패: {}", e.getMessage());
             throw new IllegalArgumentException(ErrorStatus.SESSION_ACCESS_NOT_VALID.getMessage(), e);
         }
     }


### PR DESCRIPTION
## 변동사항

-  application.yml에 mongodb와 kafka 추가됨


## 관리자 사용자 1:1 채팅 기능 구현 작업 내용

### Websocket

- websocket http 통신으로 설정(ws)
- 배포 이후에 https 통신으로 변경 예정(wss)

### STOMP Protocol
- STOMP 프로토콜을 통한 jwt 유효성 검사 완료
- StompHandler와 StompExceptionHandler를 통해 예외처리 적용

### Kafka 적용
- Kafka를 통해 MessageBroker 구현완료

### Mongodb
- mongodb를 통해 채팅 메세지와 채팅방을 `Document` 형태로 저장

### 채팅 api 구현 완료
- StompHeaderAccessor의 세션을 통해 role과 id를 저장
- 이후 ROLE_USER이면 채팅방을 생성 가능하게 허용(채팅방이 있을경우 따로 다시 생성되지 않음)
- ROLE_ADMIN이면 채팅방을 생성할 수 없지만 사용자가 채팅방을 만들어 채팅할 할 경우 subscribe와 publish 가능
- 개발 테스트 스크린샷
![스크린샷 2024-12-12 110306](https://github.com/user-attachments/assets/ff42ab25-8172-4301-976d-803cd4f839d5)



## 추후 개발 상황

- 아직 채팅방 목록 조회, 이미지 업로드 등의 api는 구현을 안한 상태
- Object Storage 연결 이후 다시 api 구현 진행 예정

