### PR TITLE
Feat/my-favorite 마이페이지 즐겨찾기 목록 조회, 검색, 삭제

### DIFF
--- a/src/main/java/com/bitcamp/drrate/domain/favorites/controller/FavoritesController.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/controller/FavoritesController.java
@@ -4,6 +4,7 @@ package com.bitcamp.drrate.domain.favorites.controller;
 
 
 import com.bitcamp.drrate.domain.favorites.dto.request.FavoritesRequestDTO;
+import com.bitcamp.drrate.domain.favorites.dto.response.FavoriteListDTO;
 import com.bitcamp.drrate.domain.favorites.dto.response.FavoritesResponseDTO;
 import com.bitcamp.drrate.domain.favorites.service.FavoritesService;
 import com.bitcamp.drrate.domain.users.dto.CustomUserDetails;
@@ -17,6 +18,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -87,25 +90,55 @@ public class FavoritesController {
 
 
   /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 조회 */
-  // public viewFavorite {}
+  @GetMapping("/getFavorite")
+  public ApiResponse<List<FavoriteListDTO>> getFavorite(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestParam("category") String category // 예금("deposit") 또는 적금("installment")
+  ) {
+    Long faUserId = usersService.getUserId(userDetails);
+
+    List<FavoriteListDTO> favoriteList =
+        favoritesService.getFavoriteList(faUserId, category);
+
+    return ApiResponse.onSuccess(favoriteList, SuccessStatus.FAVORITE_QUERY_SUCCESS);
+  }
+
+
+  /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 검색 */
+  @GetMapping("/searchFavorite")
+  public ApiResponse<List<FavoriteListDTO>> searchFavorite(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestParam("category") String category,
+      @RequestParam("searchKey") String searchKey, // 검색 기준: "bankName" 또는 "prdName"
+      @RequestParam("searchValue") String searchValue // 검색값
+  ) {
+    Long faUserId = usersService.getUserId(userDetails);
+
+    List<FavoriteListDTO> searchResults =
+        favoritesService.searchFavoriteList(faUserId, category, searchKey, searchValue);
+
+    return ApiResponse.onSuccess(searchResults, SuccessStatus.FAVORITE_QUERY_SUCCESS);
+  }
 
 
   /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 삭제 */
   // public deleteFavorite {}
   // 1 개 삭제 혹은 여러 개 삭제
-  // 여러 개 삭제 가능하도록 체크박스 입력 받음, 그 체크박스 상품 아이디를 배열로 받아야함
-  
-  
+  // 여러 개 삭제 가능하도록 체크박스 입력 받음, 그 체크박스 상품 아이디를 배열로 받아야함 (1개도 배열로 받음)
+
+  @DeleteMapping("/deleteFavorite")
+  @Transactional
+  public ApiResponse<Void> deleteFavorite(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestBody @Valid FavoritesRequestDTO.DeleteFavoriteDTO request
+  ) {
+    Long faUserId = usersService.getUserId(userDetails);
+
+    favoritesService.deleteFavoriteList(faUserId, request.getFavoriteIds());
+
+    return ApiResponse.onSuccess(null, SuccessStatus.FAVORITE_DELETE_SUCCESS);
+  }
 
 
 }
 
-//  @PostMapping(value="favoriteInsert/{id}")
-//  public ResponseEntity<Void> favoriteInsert(@PathVariable(value="id") String prd_id,
-//                                             @RequestHeader(value="userId") String user_id) {
-//    // 데이터 처리 로직 추가
-//    System.out.println("Product ID: " + prd_id);
-//    System.out.println("User ID: " + user_id);
-//
-//    return ResponseEntity.ok().build(); // HTTP 200 OK 응답
-//  }

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/controller/FavoritesController.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/controller/FavoritesController.java
@@ -10,6 +10,7 @@ import com.bitcamp.drrate.domain.favorites.service.FavoritesService;
 import com.bitcamp.drrate.domain.users.dto.CustomUserDetails;
 import com.bitcamp.drrate.domain.users.service.UsersService;
 import com.bitcamp.drrate.global.ApiResponse;
+import com.bitcamp.drrate.global.code.resultCode.ErrorStatus;
 import com.bitcamp.drrate.global.code.resultCode.SuccessStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,15 +39,19 @@ public class FavoritesController {
       @AuthenticationPrincipal CustomUserDetails userDetails, // JWT; 인증된 사용자 정보 가져오기
       @PathVariable(value = "prdId") Long prdId // URL 경로에서 파라미터를 가져옴
   ) {
-    // 1. 사용자 ID(PK)를 JWT에서 추출 & 경로 변수로 전달받은 상품 ID를 설정
-    Long faUserId = usersService.getUserId(userDetails);
-    Long faPrdId = prdId;
+    try {
+      // 1. 사용자 ID(PK)를 JWT에서 추출 & 경로 변수로 전달받은 상품 ID를 설정
+      Long faUserId = usersService.getUserId(userDetails);
+      Long faPrdId = prdId;
 
-    // 2. 서비스 호출: 추출한 faUserId와 요청으로 전달된 faPrdId를 FavoritesService 에 전달
-    boolean isFavorite = favoritesService.isFavorite(faUserId, faPrdId);
+      // 2. 서비스 호출: 추출한 faUserId와 요청으로 전달된 faPrdId를 FavoritesService 에 전달
+      boolean isFavorite = favoritesService.isFavorite(faUserId, faPrdId);
 
-    // 3. HTTP 200 OK 응답: 즐겨찾기 여부를 ApiResponse 객체로 클라이언트에 반환
-    return ApiResponse.onSuccess(isFavorite, SuccessStatus.FAVORITE_QUERY_SUCCESS);
+      // 3. HTTP 200 OK 응답: 즐겨찾기 여부를 ApiResponse 객체로 클라이언트에 반환
+      return ApiResponse.onSuccess(isFavorite, SuccessStatus.FAVORITE_QUERY_SUCCESS);
+    } catch (Exception e) {
+      return ApiResponse.onFailure(ErrorStatus.FAVORITE_QUERY_FAILED.getCode(), ErrorStatus.FAVORITE_QUERY_FAILED.getMessage(), null);
+    }
   }
 
 
@@ -57,13 +62,16 @@ public class FavoritesController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestBody @Valid FavoritesRequestDTO.ProductFavoriteDTO request
   ) {
+    try {
+      Long faUserId = usersService.getUserId(userDetails);
+      Long faPrdId = request.getPrdId(); // 요청으로 전달된 상품 ID(request.getFaPrdId())를 faPrdId에 저장
 
-    Long faUserId = usersService.getUserId(userDetails);
-    Long faPrdId = request.getPrdId(); // 요청으로 전달된 상품 ID(request.getFaPrdId())를 faPrdId에 저장
+      favoritesService.addFavorite(faUserId, faPrdId);
 
-    favoritesService.addFavorite(faUserId, faPrdId);
-
-    return ApiResponse.onSuccess(HttpStatus.OK, SuccessStatus.FAVORITE_ADD_SUCCESS);
+      return ApiResponse.onSuccess(HttpStatus.OK, SuccessStatus.FAVORITE_ADD_SUCCESS);
+    } catch (Exception e) {
+        return ApiResponse.onFailure(ErrorStatus.FAVORITE_INSERT_FAILED.getCode(), ErrorStatus.FAVORITE_INSERT_FAILED.getMessage(), null);
+    }
   }
 
 
@@ -73,17 +81,19 @@ public class FavoritesController {
   @Transactional
   public ApiResponse<HttpStatus> cancelFavorite(
       @AuthenticationPrincipal CustomUserDetails userDetails,
-      @PathVariable(value = "prdId") Long prdId // URL 경로에서 상품 ID를 가져옴
+      @PathVariable(value = "prdId") Long prdId
   ) {
-    Long faUserId = usersService.getUserId(userDetails);
-    Long faPrdId = prdId;
+    try {
+      Long faUserId = usersService.getUserId(userDetails);
+      Long faPrdId = prdId;
 
-    favoritesService.cancelFavorite(faUserId, faPrdId);
+      favoritesService.cancelFavorite(faUserId, faPrdId);
 
-    return ApiResponse.onSuccess(HttpStatus.OK, SuccessStatus.FAVORITE_DELETE_SUCCESS);
+      return ApiResponse.onSuccess(HttpStatus.OK, SuccessStatus.FAVORITE_DELETE_SUCCESS);
+    } catch (Exception e) {
+      return ApiResponse.onFailure(ErrorStatus.FAVORITE_DELETE_FAILED.getCode(), ErrorStatus.FAVORITE_DELETE_FAILED.getMessage(), null);
+    }
   }
-
-
 
 
 
@@ -95,12 +105,16 @@ public class FavoritesController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestParam("category") String category // 예금("deposit") 또는 적금("installment")
   ) {
-    Long faUserId = usersService.getUserId(userDetails);
+    try {
+      Long faUserId = usersService.getUserId(userDetails);
 
-    List<FavoriteListDTO> favoriteList =
-        favoritesService.getFavoriteList(faUserId, category);
+      List<FavoriteListDTO> favoriteList =
+          favoritesService.getFavoriteList(faUserId, category);
 
-    return ApiResponse.onSuccess(favoriteList, SuccessStatus.FAVORITE_QUERY_SUCCESS);
+      return ApiResponse.onSuccess(favoriteList, SuccessStatus.FAVORITE_QUERY_SUCCESS);
+    } catch (Exception e) {
+      return ApiResponse.onFailure(ErrorStatus.FAVORITE_QUERY_FAILED.getCode(), ErrorStatus.FAVORITE_QUERY_FAILED.getMessage(), null);
+    }
   }
 
 
@@ -108,16 +122,20 @@ public class FavoritesController {
   @GetMapping("/searchFavorite")
   public ApiResponse<List<FavoriteListDTO>> searchFavorite(
       @AuthenticationPrincipal CustomUserDetails userDetails,
-      @RequestParam("category") String category,
+      @RequestParam("category") String category, // 예금("deposit") 또는 적금("installment")
       @RequestParam("searchKey") String searchKey, // 검색 기준: "bankName" 또는 "prdName"
       @RequestParam("searchValue") String searchValue // 검색값
   ) {
-    Long faUserId = usersService.getUserId(userDetails);
+    try {
+      Long faUserId = usersService.getUserId(userDetails);
 
-    List<FavoriteListDTO> searchResults =
-        favoritesService.searchFavoriteList(faUserId, category, searchKey, searchValue);
+      List<FavoriteListDTO> searchResults =
+          favoritesService.searchFavoriteList(faUserId, category, searchKey, searchValue);
 
-    return ApiResponse.onSuccess(searchResults, SuccessStatus.FAVORITE_QUERY_SUCCESS);
+      return ApiResponse.onSuccess(searchResults, SuccessStatus.FAVORITE_QUERY_SUCCESS);
+    } catch (Exception e) {
+      return ApiResponse.onFailure(ErrorStatus.FAVORITE_QUERY_FAILED.getCode(), ErrorStatus.FAVORITE_QUERY_FAILED.getMessage(), null);
+    }
   }
 
 
@@ -132,11 +150,15 @@ public class FavoritesController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestBody @Valid FavoritesRequestDTO.DeleteFavoriteDTO request
   ) {
-    Long faUserId = usersService.getUserId(userDetails);
+    try {
+      Long faUserId = usersService.getUserId(userDetails);
 
-    favoritesService.deleteFavoriteList(faUserId, request.getFavoriteIds());
+      favoritesService.deleteFavoriteList(faUserId, request.getFavoriteIds());
 
-    return ApiResponse.onSuccess(null, SuccessStatus.FAVORITE_DELETE_SUCCESS);
+      return ApiResponse.onSuccess(null, SuccessStatus.FAVORITE_DELETE_SUCCESS);
+    } catch (Exception e) {
+        return ApiResponse.onFailure(ErrorStatus.FAVORITE_DELETE_FAILED.getCode(), ErrorStatus.FAVORITE_DELETE_FAILED.getMessage(), null);
+    }
   }
 
 

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/controller/FavoritesController.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/controller/FavoritesController.java
@@ -66,18 +66,18 @@ public class FavoritesController {
 
 
   /* ProductDetailPage; 즐겨찾기 취소 */
-  @DeleteMapping("/removeFavorite/{prdId}")
+  @DeleteMapping("/cancelFavorite/{prdId}")
   @Transactional
-  public ApiResponse<HttpStatus> removeFavorite(
+  public ApiResponse<HttpStatus> cancelFavorite(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @PathVariable Long prdId // URL 경로에서 상품 ID를 가져옴
   ) {
     Long faUserId = usersService.getUserId(userDetails);
     Long faPrdId = prdId;
 
-    favoritesService.removeFavorite(faUserId, faPrdId);
+    favoritesService.cancelFavorite(faUserId, faPrdId);
 
-    return ApiResponse.onSuccess(HttpStatus.OK, SuccessStatus.FAVORITE_REMOVE_SUCCESS);
+    return ApiResponse.onSuccess(HttpStatus.OK, SuccessStatus.FAVORITE_DELETE_SUCCESS);
   }
 
 

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/dto/request/FavoritesRequestDTO.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/dto/request/FavoritesRequestDTO.java
@@ -20,18 +20,29 @@ public class FavoritesRequestDTO {
 
 
   /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 조회 요청 */
-  // favorites 테이블의 favoriteId
-  // products 테이블의 bankLogo
-  // products 테이블의 bankName
-  // products 테이블의 prdName
-  
-  // 예금 즐겨찾기의 경우
-  // dep_options 테이블의 basic_rate
-  // dep_options 테이블의 spcl_rate
+  @Builder
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class GetFavoriteDTO {
+    @NotNull
+    private String category; // "deposit" (예금) 또는 "installment" (적금)
+  }
 
-  // 적금 즐겨찾기의 경우
-  // ins_options 테이블의 basic_rate
-  // ins_options 테이블의 spcl_rate
+
+  /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 검색 요청 */
+  @Builder
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class SearchFavoriteDTO {
+    @NotNull
+    private String category;   // "deposit" 또는 "installment"
+    @NotNull
+    private String searchKey;  // 검색 키워드 ("bankName" 또는 "prdName")
+    @NotNull
+    private String searchValue; // 검색값 (사용자가 입력한 값)
+  }
 
 
 

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/dto/response/FavoriteListDTO.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/dto/response/FavoriteListDTO.java
@@ -1,0 +1,20 @@
+/* src/main/java/com/bitcamp/drrate/domain/favorites/dto/response/FavoriteListDTO.java */
+
+package com.bitcamp.drrate.domain.favorites.dto.response;
+
+import lombok.*;
+import java.math.BigDecimal;
+
+/* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 조회 응답 */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FavoriteListDTO {
+  private Long favoriteId;        // 즐겨찾기 ID
+  private String bankLogo;        // 은행 로고
+  private String bankName;        // 은행 이름
+  private String prdName;         // 상품 이름
+  private BigDecimal basicRate;   // 기본 금리
+  private BigDecimal spclRate;    // 최고 금리
+}

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/dto/response/FavoritesResponseDTO.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/dto/response/FavoritesResponseDTO.java
@@ -17,20 +17,6 @@ public class FavoritesResponseDTO {
   }
 
 
-  /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 조회 응답 */
-  @Builder
-  @Getter
-  @AllArgsConstructor
-  @NoArgsConstructor
-  public static class FavoriteListDTO {
-    private Long favoriteId;        // 즐겨찾기 ID
-    private String bankLogo;        // 은행 로고
-    private String bankName;        // 은행 이름
-    private String prdName;         // 상품 이름
-    private BigDecimal basicRate;   // 기본 금리
-    private BigDecimal spclRate;    // 최고 금리
-  }
-
 
   /* MyDepositPage, MyInstallmentPage; 즐겨찾기 삭제 응답 (체크박스로 여러 개(1개 이상) 삭제) */
   @Builder

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/repository/FavoritesRepository.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/repository/FavoritesRepository.java
@@ -3,9 +3,15 @@
 
 package com.bitcamp.drrate.domain.favorites.repository;
 
+import com.bitcamp.drrate.domain.favorites.dto.response.FavoriteListDTO;
+import com.bitcamp.drrate.domain.favorites.dto.response.FavoritesResponseDTO;
 import com.bitcamp.drrate.domain.favorites.entity.Favorites;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
@@ -13,4 +19,65 @@ public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
   boolean existsByUserIdAndProductId(Long faUserId, Long faPrdId);
 
   void deleteByUserIdAndProductId(Long faUserId, Long faPrdId);
+
+
+  /* 마이페이지; 예금 목록 조회 */
+  @Query("SELECT new com.bitcamp.drrate.domain.favorites.dto.response.FavoriteListDTO(\n" +
+      "f.id, p.bankLogo, p.bankName, p.prdName, MAX(d.basicRate), MAX(d.spclRate)) " +
+      "FROM Favorites f " +
+      "JOIN f.product p " +
+      "JOIN DepositeOptions d ON p.id = d.products.id " +
+      "WHERE f.user.id = :faUserId " +
+      "GROUP BY f.id, p.bankLogo, p.bankName, p.prdName " +
+      "ORDER BY f.id DESC")
+  List<FavoriteListDTO> findDepositsByUserId(@Param("faUserId") Long faUserId);
+
+
+  /* 마이페이지; 적금 목록 조회 */
+  @Query("SELECT new com.bitcamp.drrate.domain.favorites.dto.response.FavoriteListDTO(\n" +
+      "f.id, p.bankLogo, p.bankName, p.prdName, MAX(i.basicRate), MAX(i.spclRate)) " +
+      "FROM Favorites f " +
+      "JOIN f.product p " +
+      "JOIN InstallMentOptions i ON p.id = i.products.id " +
+      "WHERE f.user.id = :faUserId " +
+      "GROUP BY f.id, p.bankLogo, p.bankName, p.prdName " +
+      "ORDER BY f.id DESC")
+  List<FavoriteListDTO> findInstallmentsByUserId(@Param("faUserId") Long faUserId);
+
+
+
+  /* 마이페이지; 예금 검색 */
+  @Query("SELECT new com.bitcamp.drrate.domain.favorites.dto.response.FavoriteListDTO(\n" +
+      "f.id, p.bankLogo, p.bankName, p.prdName, MAX(d.basicRate), MAX(d.spclRate)) " +
+      "FROM Favorites f " +
+      "JOIN f.product p " +
+      "JOIN DepositeOptions d ON p.id = d.products.id " +
+      "WHERE f.user.id = :faUserId AND ((:searchKey = 'bankName' AND p.bankName LIKE %:searchValue%) OR \n" +
+      "(:searchKey = 'prdName' AND p.prdName LIKE %:searchValue%)) " +
+      "GROUP BY f.id, p.bankLogo, p.bankName, p.prdName " +
+      "ORDER BY f.id DESC")
+  List<FavoriteListDTO> searchDepositsByUserId(@Param("faUserId") Long faUserId,
+                                               @Param("searchKey") String searchKey,
+                                               @Param("searchValue") String searchValue);
+
+
+
+
+  /* 마이페이지; 적금 검색 */
+  @Query("SELECT new com.bitcamp.drrate.domain.favorites.dto.response.FavoriteListDTO(\n" +
+      "f.id, p.bankLogo, p.bankName, p.prdName, MAX(i.basicRate), MAX(i.spclRate)) " +
+      "FROM Favorites f " +
+      "JOIN f.product p " +
+      "JOIN InstallMentOptions i ON p.id = i.products.id " +
+      "WHERE f.user.id = :faUserId AND ((:searchKey = 'bankName' AND p.bankName LIKE %:searchValue%) OR \n" +
+      "(:searchKey = 'prdName' AND p.prdName LIKE %:searchValue%)) " +
+      "GROUP BY f.id, p.bankLogo, p.bankName, p.prdName " +
+      "ORDER BY f.id DESC")
+  List<FavoriteListDTO> searchInstallmentsByUserId(@Param("faUserId") Long faUserId,
+                                                   @Param("searchKey") String searchKey,
+                                                   @Param("searchValue") String searchValue);
+
+
+  /* 마이페이지; 즐겨찾기 배열 삭제 */
+  void deleteById(Long favoriteId);
 }

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/service/FavoriteServiceImpl.java
@@ -110,21 +110,7 @@ public class FavoriteServiceImpl implements FavoritesService {
   }
 
 
-
-  // getFavoriteList(), searchFavoriteList()
-  // favorites 테이블의 favoriteId
-  // products 테이블의 bankLogo
-  // products 테이블의 bankName
-  // products 테이블의 prdName
-
-  // 예금 즐겨찾기의 경우
-  // dep_options 테이블의 basic_rate
-  // dep_options 테이블의 spcl_rate
-
-  // 적금 즐겨찾기의 경우
-  // ins_options 테이블의 basic_rate
-  // ins_options 테이블의 spcl_rate
-
+  /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 조회 */
   @Override
   public List<FavoriteListDTO> getFavoriteList(Long faUserId, String category) {
     try {
@@ -145,9 +131,15 @@ public class FavoriteServiceImpl implements FavoritesService {
     }
   }
 
+  /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 검색 */
   @Override
   public List<FavoriteListDTO> searchFavoriteList(Long faUserId, String category, String searchKey, String searchValue) {
     try {
+      System.out.println("User ID: " + faUserId);
+      System.out.println("Category: " + category);
+      System.out.println("SearchKey: " + searchKey);
+      System.out.println("SearchValue: " + searchValue);
+
       if ("deposit".equalsIgnoreCase(category)) {
         return favoritesRepository.searchDepositsByUserId(faUserId, searchKey, searchValue);
       } else if ("installment".equalsIgnoreCase(category)) {
@@ -159,6 +151,7 @@ public class FavoriteServiceImpl implements FavoritesService {
     }
   }
 
+  /* MyDepositPage, MyInstallmentPage; 즐겨찾기 목록 삭제 */
   @Override
   public void deleteFavoriteList(Long faUserId, @NotNull Long[] favoriteIds) {
     List<Long> failedIds = new ArrayList<>();
@@ -182,5 +175,5 @@ public class FavoriteServiceImpl implements FavoritesService {
     }
   }
 
-
 }
+

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/service/FavoriteServiceImpl.java
@@ -85,7 +85,7 @@ public class FavoriteServiceImpl implements FavoritesService {
   /* ProductDetailPage; 즐겨찾기 취소 */
   @Override
   @Transactional
-  public void removeFavorite(Long faUserId, Long faPrdId) {
+  public void cancelFavorite(Long faUserId, Long faPrdId) {
     // Users 및 Products 엔티티를 조회
     Users user = usersRepository.findById(faUserId)
         .orElseThrow(() -> new FavoritesServiceExceptionHandler(ErrorStatus.FAVORITE_INVALID_USER_ID));

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/service/FavoritesService.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/service/FavoritesService.java
@@ -3,6 +3,12 @@
 
 package com.bitcamp.drrate.domain.favorites.service;
 
+import com.bitcamp.drrate.domain.favorites.dto.response.FavoriteListDTO;
+import com.bitcamp.drrate.domain.favorites.dto.response.FavoritesResponseDTO;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
 public interface FavoritesService {
 
   boolean isFavorite(Long faUserId, Long faPrdId);
@@ -10,4 +16,10 @@ public interface FavoritesService {
   void addFavorite(Long faUserId, Long faPrdId);
 
   void cancelFavorite(Long faUserId, Long faPrdId);
+
+  List<FavoriteListDTO> getFavoriteList(Long faUserId, String category);
+
+  List<FavoriteListDTO> searchFavoriteList(Long faUserId, String category, String searchKey, String searchValue);
+
+  void deleteFavoriteList(Long faUserId, @NotNull Long[] favoriteIds);
 }

--- a/src/main/java/com/bitcamp/drrate/domain/favorites/service/FavoritesService.java
+++ b/src/main/java/com/bitcamp/drrate/domain/favorites/service/FavoritesService.java
@@ -9,5 +9,5 @@ public interface FavoritesService {
 
   void addFavorite(Long faUserId, Long faPrdId);
 
-  void removeFavorite(Long faUserId, Long faPrdId);
+  void cancelFavorite(Long faUserId, Long faPrdId);
 }

--- a/src/main/java/com/bitcamp/drrate/global/code/resultCode/ErrorStatus.java
+++ b/src/main/java/com/bitcamp/drrate/global/code/resultCode/ErrorStatus.java
@@ -85,7 +85,12 @@ public enum ErrorStatus implements ErrorCode {
     FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "FAV403", "즐겨찾기 데이터를 찾을 수 없습니다."),
     FAVORITE_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV404", "즐겨찾기 조회에 실패했습니다."),
     FAVORITE_INSERT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV405", "즐겨찾기 등록에 실패했습니다."),
-    FAVORITE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV406", "즐겨찾기 삭제에 실패했습니다."),
+    FAVORITE_SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV406", "즐겨찾기 검색에 실패했습니다."),
+    FAVORITE_NO_RESULTS(HttpStatus.OK, "FAV407", "검색된 즐겨찾기 데이터가 없습니다."),
+    FAVORITE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV408", "즐겨찾기 삭제에 실패했습니다."),
+    FAVORITE_PARTIAL_DELETE_FAILED(HttpStatus.PARTIAL_CONTENT, "FAV409", "일부 즐겨찾기 삭제에 실패했습니다."),
+
+
 
 
     // 권한 에러

--- a/src/main/java/com/bitcamp/drrate/global/code/resultCode/ErrorStatus.java
+++ b/src/main/java/com/bitcamp/drrate/global/code/resultCode/ErrorStatus.java
@@ -94,7 +94,7 @@ public enum ErrorStatus implements ErrorCode {
     FAVORITE_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV404", "즐겨찾기 조회에 실패했습니다."),
     FAVORITE_INSERT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV405", "즐겨찾기 등록에 실패했습니다."),
     FAVORITE_SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV406", "즐겨찾기 검색에 실패했습니다."),
-    FAVORITE_NO_RESULTS(HttpStatus.OK, "FAV407", "검색된 즐겨찾기 데이터가 없습니다."),
+    FAVORITE_NO_RESULTS(HttpStatus.OK, "FAV407", "조회된 즐겨찾기 데이터가 없습니다."),
     FAVORITE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FAV408", "즐겨찾기 삭제에 실패했습니다."),
     FAVORITE_PARTIAL_DELETE_FAILED(HttpStatus.PARTIAL_CONTENT, "FAV409", "일부 즐겨찾기 삭제에 실패했습니다."),
 

--- a/src/main/java/com/bitcamp/drrate/global/code/resultCode/SuccessStatus.java
+++ b/src/main/java/com/bitcamp/drrate/global/code/resultCode/SuccessStatus.java
@@ -39,7 +39,7 @@ public enum SuccessStatus implements SuccessCode {
     // Favorite
     FAVORITE_QUERY_SUCCESS(HttpStatus.OK, "FAV200", "즐겨찾기 조회 성공"),
     FAVORITE_ADD_SUCCESS(HttpStatus.OK, "FAV201", "즐겨찾기 등록 성공"),
-    FAVORITE_REMOVE_SUCCESS(HttpStatus.OK, "FAV202", "즐겨찾기 취소 성공")
+    FAVORITE_DELETE_SUCCESS(HttpStatus.OK, "FAV202", "즐겨찾기 취소 성공")
     ;
 
 


### PR DESCRIPTION
# 구현할 기능
- 마이페이지 즐겨찾기 조회, 검색, 삭제

# 상세내용 
- `MyDepositPage`, `MyInstallmentPage` (마이페이지) 즐겨찾기 페이지 조회, 검색, 삭제

## 1. 마이페이지 즐겨찾기 조회 `getFavorite()`
###  `MyDepositPage` 즐겨찾기 목록 조회
![image](https://github.com/user-attachments/assets/5c0493cd-b410-41b0-a1df-6da8d85715c1)

###  `MyInstallmentPage` 즐겨찾기 목록 조회
![image](https://github.com/user-attachments/assets/161ff478-923b-46c0-bf3a-a8b5e65904ad)

---
##  2. 마이페이지 즐겨찾기 검색 `searchFavorite`
###  `MyDepositPage` 즐겨찾기 목록 검색 
![image](https://github.com/user-attachments/assets/1d86edf3-1850-4936-8834-346925977726)

###  `MyInstallmentPage` 즐겨찾기 목록 검색 
![image](https://github.com/user-attachments/assets/bbf4f46c-aef8-4c3c-b25f-6fdbfef0aa60)

---
##  3. 마이페이지 즐겨찾기 삭제 `deleteFavorite`
###  즐겨찾기 목록 1개 삭제 
![image](https://github.com/user-attachments/assets/01f6cb16-20f2-46c0-8356-ce068908042e)

###  즐겨찾기 목록 2개 이상 삭제 
![image](https://github.com/user-attachments/assets/f801e0d9-aac4-4915-b7fb-c9287b311481)

---
## 4. 삭제 예외처리
### 모든 ID가 존재하지 않을 경우
![image](https://github.com/user-attachments/assets/7172faef-4db8-4c2f-9ebb-f5164387e297)

### 일부 ID만 존재하지 않는 경우
![image](https://github.com/user-attachments/assets/5dc1e66a-17ca-4438-bacb-7bdbfc06863a)

### 조회, 검색도 예외처리 있으나 테스트는 굳이,,입니다.

